### PR TITLE
Fixes/changes following feedback

### DIFF
--- a/ui/snapclient/src/app/mapping/mapping-import/mapping-import.component.css
+++ b/ui/snapclient/src/app/mapping/mapping-import/mapping-import.component.css
@@ -34,3 +34,7 @@ mat-icon {
   flex: 50%;
   padding: 10px;
 }
+
+.header-row {
+  background-color: gainsboro
+}

--- a/ui/snapclient/src/app/mapping/mapping-import/mapping-import.component.html
+++ b/ui/snapclient/src/app/mapping/mapping-import/mapping-import.component.html
@@ -59,7 +59,7 @@
         </ng-container>
       
         <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-        <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+        <tr mat-row [ngClass]="{'header-row': i === 0}" *matRowDef="let row; columns: displayedColumns; let i = index"></tr>
       </table>
     </section>
   </div>

--- a/ui/snapclient/src/app/mapping/mapping-import/mapping-import.component.ts
+++ b/ui/snapclient/src/app/mapping/mapping-import/mapping-import.component.ts
@@ -33,7 +33,7 @@ interface RowColumn {
 }
 
 const SOURCE_CODE_OPTION_LABEL = 'Source Code';
-const SOURCE_DISPLAY_OPTION_LABEL = 'Source Display';
+//const SOURCE_DISPLAY_OPTION_LABEL = 'Source Display';
 const TARGET_CODE_OPTION_LABEL = 'Target Code';
 const TARGET_DISPLAY_OPTION_LABEL = 'Target Display';
 const RELATIONSHIP_TYPE_CODE_OPTION_LABEL = 'Relationship Type Code';
@@ -67,7 +67,7 @@ export class MappingImportComponent implements OnInit, OnDestroy, AfterViewCheck
 
   columns: RowColumn[] = [
     {value: SOURCE_CODE_OPTION_VALUE, viewValue: SOURCE_CODE_OPTION_LABEL},
-    {value: SOURCE_DISPLAY_OPTION_VALUE, viewValue: SOURCE_DISPLAY_OPTION_LABEL},
+//    {value: SOURCE_DISPLAY_OPTION_VALUE, viewValue: SOURCE_DISPLAY_OPTION_LABEL},
     {value: TARGET_CODE_OPTION_VALUE, viewValue: TARGET_CODE_OPTION_LABEL},
     {value: TARGET_DISPLAY_OPTION_VALUE, viewValue: TARGET_DISPLAY_OPTION_LABEL},
     {value: RELATIONSHIP_TYPE_CODE_OPTION_VALUE, viewValue: RELATIONSHIP_TYPE_CODE_OPTION_LABEL},
@@ -243,9 +243,9 @@ export class MappingImportComponent implements OnInit, OnDestroy, AfterViewCheck
         case (SOURCE_CODE_OPTION_LABEL.toLowerCase() || ALT_SOURCE_CODE_OPTION_LABEL): { 
           return SOURCE_CODE_OPTION_VALUE; 
         } 
-        case SOURCE_DISPLAY_OPTION_LABEL.toLowerCase(): { 
-           return SOURCE_DISPLAY_OPTION_VALUE;
-        } 
+        // case SOURCE_DISPLAY_OPTION_LABEL.toLowerCase(): { 
+        //    return SOURCE_DISPLAY_OPTION_VALUE;
+        // } 
         case (TARGET_CODE_OPTION_LABEL.toLowerCase() || ALT_TARGET_CODE_OPTION_LABEL): { 
           return TARGET_CODE_OPTION_VALUE;
         } 
@@ -273,6 +273,32 @@ export class MappingImportComponent implements OnInit, OnDestroy, AfterViewCheck
   updateSelection2(newValue : string, index : number): void {
     
     this.error.message = "";
+
+    // remove previous selection
+    if (this.codeColumnIndexArray.includes(index)) { 
+      const arrayIndex = this.codeColumnIndexArray.indexOf(index);
+      this.codeColumnIndexArray.splice(arrayIndex, 1);
+    } 
+    else if (this.targetCodeColumnIndexArray.includes(index)) {
+      const arrayIndex = this.targetCodeColumnIndexArray.indexOf(index);         
+      this.targetCodeColumnIndexArray.splice(arrayIndex, 1);
+    }
+    else if (this.targetDisplayColumnIndexArray.includes(index)) {
+      const arrayIndex = this.targetDisplayColumnIndexArray.indexOf(index);
+      this.targetDisplayColumnIndexArray.splice(arrayIndex, 1);
+    }
+    else if (this.relationshipColumnIndexArray.includes(index)) { 
+      const arrayIndex = this.relationshipColumnIndexArray.indexOf(index);
+      this.relationshipColumnIndexArray.splice(arrayIndex, 1);
+    }
+    else if (this.noMapFlagColumnIndexArray.includes(index)) {
+      const arrayIndex = this.noMapFlagColumnIndexArray.indexOf(index);
+      this.noMapFlagColumnIndexArray.splice(arrayIndex, 1);
+    }
+    else if (this.statusColumnIndexArray.includes(index)) {
+      const arrayIndex = this.statusColumnIndexArray.indexOf(index);
+      this.statusColumnIndexArray.splice(arrayIndex, 1);
+    }
 
     switch(newValue) { 
       case SOURCE_CODE_OPTION_VALUE: { 
@@ -303,37 +329,8 @@ export class MappingImportComponent implements OnInit, OnDestroy, AfterViewCheck
         this.statusColumnIndexArray.push(index);
         break;
       }
-      case undefined: {
-
-        // user has selected the empty option
-
-        if (this.codeColumnIndexArray.includes(index)) { 
-          const arrayIndex = this.codeColumnIndexArray.indexOf(index);
-          this.codeColumnIndexArray.splice(arrayIndex, 1);
-        } 
-        else if (this.targetCodeColumnIndexArray.includes(index)) {
-          const arrayIndex = this.targetCodeColumnIndexArray.indexOf(index);         
-          this.targetCodeColumnIndexArray.splice(arrayIndex, 1);
-        }
-        else if (this.targetDisplayColumnIndexArray.includes(index)) {
-          const arrayIndex = this.targetDisplayColumnIndexArray.indexOf(index);
-          this.targetDisplayColumnIndexArray.splice(arrayIndex, 1);
-        }
-        else if (this.relationshipColumnIndexArray.includes(index)) { 
-          const arrayIndex = this.relationshipColumnIndexArray.indexOf(index);
-          this.relationshipColumnIndexArray.splice(arrayIndex, 1);
-        }
-        else if (this.noMapFlagColumnIndexArray.includes(index)) {
-          const arrayIndex = this.noMapFlagColumnIndexArray.indexOf(index);
-          this.noMapFlagColumnIndexArray.splice(arrayIndex, 1);
-        }
-        else if (this.statusColumnIndexArray.includes(index)) {
-          const arrayIndex = this.statusColumnIndexArray.indexOf(index);
-          this.statusColumnIndexArray.splice(arrayIndex, 1);
-        }
-        break;
-      }
       default: { 
+        // undefined = empty selection
          break; 
       } 
 

--- a/ui/snapclient/src/assets/i18n/en.json
+++ b/ui/snapclient/src/assets/i18n/en.json
@@ -445,7 +445,7 @@
   "IMPORT" : {
     "IMPORT_INFO": "The mapping import file must include a header row. \n\n Large maps can take long to import, please do not refresh your browser while the import is running.",
     "IMPORT_LARGE_MAP": "Large maps can take long to import, please do not refresh your browser while the import is running.",
-    "IMPORT_WARNING": "Warning! This operation will clear and override all existing mapping!",
+    "IMPORT_WARNING": "Warning! This operation will clear and override all existing mappings!",
     "IMPORT_RESULT": "Successfully imported {{insertCount}} lines from {{recordCount}} lines.",
     "IMPORT_SELECT_COLUMNS": "We have selected columns for import where possible. Please check these are correct as they cannot be changed later."
   }


### PR DESCRIPTION
-fix warning message to read mappings instead of mapping
-remove source display as an option to map columns to as it isn't actually used
-fix selection error causing wrong reporting multiple column selection
-change background of first row of sample file to a different colour to signify the header
-prevent import of bad mappings (target code with no map=true, target code with unmapped status)
