### PR TITLE
Disable Trivy secret scanning

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -70,8 +70,8 @@ stages:
             displayName: "Run trivy scan on snap2snomed"
             inputs:
               script: |
-                trivy image --exit-code 0 --severity LOW,MEDIUM $(dockerRegistry)/$(registryPath):$(Build.BuildNumber)
-                trivy image --exit-code 1 --severity HIGH,CRITICAL $(dockerRegistry)/$(registryPath):$(Build.BuildNumber)
+                trivy image --exit-code 0 --severity LOW,MEDIUM --security-checks vuln $(dockerRegistry)/$(registryPath):$(Build.BuildNumber)
+                trivy image --exit-code 1 --severity HIGH,CRITICAL --security-checks vuln $(dockerRegistry)/$(registryPath):$(Build.BuildNumber)
           - script: |
               export VERSION=`git rev-parse --short=7 HEAD` && \
               yarn exec sentry-cli releases new $VERSION && \


### PR DESCRIPTION
This change disables secret scanning by the Trivy tool, which is quite expensive and only occurs after the secret has already been pushed to the remote repository, in this case.

Suggest use of [GitGuardian](https://www.gitguardian.com/) for secret scanning - it is capable of preventing secrets being committed in the first place.