### PR TITLE
Only one docker push image task, trivy version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,16 +15,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Updated Trivy version to prevent database hanging.
 - Updated library versions to mitigate CVEs:
- -
+  -
 
-#### Changed
+### Changed
 
+- Streamlined the Docker image tag pushing process.
 - SNOMED-457: streamline login process (DEX)
 - SNOMED-499: expand export to include additional source columns
-- SNOMED-500: export notes, author and reviewer
+- SNOMED-500: export notes, author, and reviewer
 
-#### Fixed
+### Fixed
 
 - SNOMED-496: Hiding index column causes filters to be misaligned
 - SNOMED-475: Import error never goes away

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,7 @@ pool:
 variables:
   mavenCache: $(Pipeline.Workspace)/.m2/repository
   mavenOptions: '-Dmaven.repo.local=$(mavenCache)'
-  trivyVersion: 0.27.1
+  trivyVersion: 0.46.0
 
 stages:
   - stage: build
@@ -83,6 +83,14 @@ stages:
               SENTRY_ORG: $(sentryOrg)
               SENTRY_PROJECT: $(sentryProject)
               SENTRY_AUTH_TOKEN: $(sentryAuthToken)
+          - script: |
+              if [[ "$(Build.SourceBranch)" == "refs/heads/main" ]]; then
+                echo "##vso[task.setvariable variable=DOCKER_TAG]$(Build.BuildNumber)"
+              else
+                echo "##vso[task.setvariable variable=DOCKER_TAG]$(Build.SourceBranchName)"
+              fi
+            displayName: Determine Docker Tag
+            condition: succeeded()
           - task: Docker@2
             condition: succeeded()
             displayName: Push image
@@ -90,17 +98,7 @@ stages:
               containerRegistry: $(serviceConnection)
               repository: $(registryPath)
               command: push
-              tags: |
-                $(Build.SourceBranchName)
-          - task: Docker@2
-            condition: contains(variables['build.sourceBranch'], 'refs/heads/main')
-            displayName: Push image
-            inputs:
-              containerRegistry: $(serviceConnection)
-              repository: $(registryPath)
-              command: push
-              tags: |
-                $(Build.BuildNumber)
+              tags: $(DOCKER_TAG)
           - task: PublishPipelineArtifact@1
             inputs:
               targetPath: '$(System.DefaultWorkingDirectory)/ui/target/site'


### PR DESCRIPTION
# Pull Request Template

## Description

This PR updates the Trivy version to prevent database hanging during scans and streamlines the Docker image tag pushing process in the Azure pipeline. These changes were motivated by a need to enhance the security and efficiency of our CI/CD processes.

Fixes 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

The changes were tested on an Azure pipeline. The build results, including logs and test outcomes, can be viewed at the following link: [Azure Pipeline Build #10669](https://dev.azure.com/aehrc/ontoserver/_build/results?buildId=10669&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3)

- [x] Trivy database hanging issue resolved.
- [x] Docker image tag pushing streamlined and verified.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass with my changes
